### PR TITLE
Removed obsolete requirement for setting some environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
 # maidsafe_config
 
-Before using this script, see the maidsafe forums for info re. installing libsodium and other environment tweaks.
+Before using this script, see the MaidSafe forums for info re. any environment tweaks.
 Make sure you have the latest stable version of rustc and cargo from http://rust-lang.org.
-You'll want to set these in your .bashrc:
+You might want to set this in your .bashrc:
 
-  export SODIUM_LIB_DIR=/usr/local/lib
-
-  export RUST_TEST_THREADS=1
-  
+    export RUST_BACKTRACE=1
 
 Run the script with no arguments to see the options.
 
-./runner.py
+    ./runner.py

--- a/runner.py
+++ b/runner.py
@@ -1,11 +1,5 @@
 #!/usr/bin/env python
 
-# Note, in your .bashrc, put: 
-#  export SODIUM_LIB_DIR=/usr/local/lib
-#  export RUST_TEST_THREADS=1
-# See maidsafe forums for info re. installing libsodium
-# and other configuration tips.
-
 import os
 import subprocess
 import sys
@@ -14,7 +8,7 @@ def call_with_cwd(project, exec_args):
   # Use Popen to set directory in project
   p = subprocess.Popen(exec_args, cwd=project)
   p.wait()
-  
+
 def cargo_build_or_test(project, options, use_mock_routing=False):
   if "test" in options:
     print "test " + project
@@ -24,7 +18,7 @@ def cargo_build_or_test(project, options, use_mock_routing=False):
     cargo_args = ["cargo", "build"]
 
   # Add mock routing feature if specified
-  if (use_mock_routing): 
+  if (use_mock_routing):
     cargo_args.extend(["--features", "use-mock-routing"])
 
   call_with_cwd(project, cargo_args)
@@ -34,26 +28,25 @@ def do_runner(options):
     "accumulator",
     "config_file_handler",
     "crust",
-    "drive",
-    "kademlia_routing_table", 
+    "kademlia_routing_table",
     "lru_time_cache",
     "maidsafe_utilities",
     "routing",
     "rust_sodium",
-    "safe_core", 
+    "safe_core",
     "safe_launcher",
     "safe_vault",
     "secure_serialisation",
     "self_encryption",
   ]
   mock_routing_projects = [
-    "safe_core", 
+    "safe_core",
     "safe_launcher",
   ]
   node_projects = [
     "safe_launcher"
   ]
- 
+
   for project in projects:
     if "clone" in options:
       print "git clone " + project
@@ -72,27 +65,18 @@ def do_runner(options):
       if "build" in options or "test" in options:
         mock_routing = project in mock_routing_projects
         cargo_build_or_test(project, options, use_mock_routing=mock_routing)
-  
+
 def check_env():
   print "Running environment checks."
   ret = True
 
-  # Check required executables 
+  # Check required executables
   for prog in ["cargo", "rustc", "git"]:
     try:
       subprocess.call([prog, "--version"])
     except:
       print "** Trouble finding version of " + prog
       ret = False
-
-  # Check required env vars
-  for env_key in ["RUST_TEST_THREADS", "SODIUM_LIB_DIR"]:
-    env_val = os.environ.get(env_key)
-    if env_val is None:
-      print "** " + env_key + " env var not set."
-      ret = False
-    else:
-      print env_key + " is " + env_val
   return ret
 
 # Check for a few simple command line args.
@@ -100,7 +84,7 @@ options = ["build", "clean", "clone", "pull", "test", "update"]
 if len(sys.argv) < 2:
   print "Please specify at least one of: " + ", ".join(options)
 elif not check_env():
-  print "Environment checks failed." 
-  print "See maidsafe forums for tips on fixing your environment."
-else: 
+  print "Environment checks failed."
+  print "See MaidSafe forums for tips on fixing your environment."
+else:
   do_runner(sys.argv)


### PR DESCRIPTION
There should be no need to set either `SODIUM_LIB_DIR` or `RUST_TEST_THREADS` now.

Since we forked sodiumoxide to our own repo at rust_sodium, the building of libsodium is all handled automatically, removing the need to tell the linker via `SODIUM_LIB_DIR` where libsodium is located.

Also, Crust was updated a while back to no longer require its tests to run single-threaded (I _think_ that was the only repo which required `RUST_TEST_THREADS` set to `1`, but either way, I'm pretty sure we don't have this requirement in any of our projects now).

The removal of the trailing spaces from the script was done automatically by my editor - I didn't really notice until I saw the diff on GitHub - sorry!

I also pulled `drive` from the list of projects as we've mothballed it for now.
